### PR TITLE
test/s3_rules_000.rego: condense policy code

### DIFF
--- a/test/s3_rules_000.rego
+++ b/test/s3_rules_000.rego
@@ -1,12 +1,9 @@
 package dev.eunomia.testing
 
 s3_read_write_global[msg] {
-  some i, j  
-  sid := input.iam[i].Statement[j].Sid  
-  effect := input.iam[i].Statement[j].Effect  
-  action := input.iam[i].Statement[j].Action
-  effect == "Allow"
-  action == "s3:*"
-  msg := sprintf("Policy '%v' allows to read/write all S3 buckets", [sid])
+  stmt := input.iam[_].Statement[_]
+  stmt.Effect == "Allow"
+  stmt.Action == "s3:*"
+  msg := sprintf("Policy '%v' allows to read/write all S3 buckets", [stmt.Sid])
 }
 


### PR DESCRIPTION
It could be taken further, too:

    s3_read_write_global[sprintf("Policy '%v' allows to read/write all S3 buckets", [stmt.Sid])] {
      stmt := input.iam[_].Statement[_]
      stmt.Effect == "Allow"
      stmt.Action == "s3:*"
    }

but I think that's where readability starts to suffer.

This is largely a matter of taste, I suppose.
